### PR TITLE
iframe dev autoreload bug fix

### DIFF
--- a/src/components/lib/IFrame.tsx
+++ b/src/components/lib/IFrame.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { classNames } from "@/utils";
+import React, { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+interface IFrameProps {
+  className?: string;
+  children: React.ReactElement;
+}
+
+const IFrame = ({ children, className = "" }: IFrameProps) => {
+  const ref = useRef<HTMLIFrameElement>(null);
+  const [iframeDoc, setIframeDoc] = useState<Document>();
+  const [loadBody, setLoadBody] = useState(false);
+
+  useEffect(() => {
+    setIframeDoc(ref.current?.contentWindow?.document);
+  }, []);
+
+  useEffect(() => {
+    if (iframeDoc) {
+      const stylesheet = document.querySelector<HTMLLinkElement>(
+        "link[rel=stylesheet]",
+      );
+
+      if (stylesheet) {
+        const link = iframeDoc.createElement("link");
+        link.rel = "stylesheet";
+        link.href = stylesheet.href;
+
+        link.onload = () => {
+          setLoadBody(true);
+        };
+
+        iframeDoc.head.appendChild(link);
+      }
+    }
+  }, [iframeDoc]);
+
+  return (
+    <iframe ref={ref} className={classNames(className)}>
+      {iframeDoc && loadBody && createPortal(children, iframeDoc.body)}
+    </iframe>
+  );
+};
+
+export default IFrame;

--- a/src/components/lib/PreviewCard.tsx
+++ b/src/components/lib/PreviewCard.tsx
@@ -48,6 +48,11 @@ const PreviewCard = ({ children, className }: PreviewCardProps) => {
         )}
         srcDoc={`
       <script src="https://cdn.tailwindcss.com"></script>
+      ${
+        process.env.NODE_ENV && process.env.NODE_ENV === "development"
+          ? '<script>const host=window.parent.location.host;const socket=new WebSocket("ws://"+host+"/_next/webpack-hmr");socket.onmessage=(message)=>{const{action}=JSON.parse(message.data);if(action==="built")window.parent.location.reload()}</script>'
+          : ""
+      }
       ${renderHTMLFromJSX(children)}`}
       ></iframe>
     </div>

--- a/src/components/lib/PreviewCard.tsx
+++ b/src/components/lib/PreviewCard.tsx
@@ -1,6 +1,7 @@
-import { classNames, renderHTMLFromJSX } from "@/utils";
+import { classNames } from "@/utils";
 import { useEffect, useRef, useState } from "react";
 import WidthHandler from "./WidthHandler";
+import IFrame from "./IFrame";
 
 interface PreviewCardProps {
   className?: string;
@@ -42,19 +43,13 @@ const PreviewCard = ({ children, className }: PreviewCardProps) => {
           "iframe-overlay absolute inset-0 z-20 mx-auto hidden h-full min-h-[865px] w-full overflow-auto rounded-md border",
         )}
       ></div>
-      <iframe
+      <IFrame
         className={classNames(
           "z-10 mx-auto min-h-[865px] w-full overflow-auto rounded-md border",
         )}
-        srcDoc={`
-      <script src="https://cdn.tailwindcss.com"></script>
-      ${
-        process.env.NODE_ENV && process.env.NODE_ENV === "development"
-          ? '<script>const host=window.parent.location.host;const socket=new WebSocket("ws://"+host+"/_next/webpack-hmr");socket.onmessage=(message)=>{const{action}=JSON.parse(message.data);if(action==="built")window.parent.location.reload()}</script>'
-          : ""
-      }
-      ${renderHTMLFromJSX(children)}`}
-      ></iframe>
+      >
+        {children}
+      </IFrame>
     </div>
   );
 };


### PR DESCRIPTION
## **CURRENT BEHAVIOUR:**
In the development, when the template code changes we need to refresh the whole window to see the changes, as we are using `iframe` to render the templates, independent of the actual devui project styling.

## **EXPECTED BEHAVIOUR:**
We want to add logic which will do a hot reloading without refreshing the screen when we change the code inside the template. This saves time as we don't need to refresh the page to see the changes in the development.